### PR TITLE
[IA-2687] csp fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,15 +62,14 @@ jobs:
       run: |
         docker push ${{ steps.construct-tags.outputs.sha-tag }}
         docker push ${{ steps.construct-tags.outputs.environment-tag }}
-    # TODO: uncomment when calhoun exists in terra-helmfile
-    #- name: Dispatch to terra-helmfile
-    #  if: github.event_name == 'push'
-    #  uses: broadinstitute/repository-dispatch@master
-    #  with:
-    #    token: ${{ secrets.BROADBOT_TOKEN }}
-    #    repository: broadinstitute/terra-helmfile
-    #    event-type: update-service
-    #    client-payload: '{"service": "calhoun", "version": "${{ steps.short-sha.outputs.sha }}", "dev_only": false}'
+    - name: Dispatch to terra-helmfile
+     if: github.event_name == 'push'
+     uses: broadinstitute/repository-dispatch@master
+     with:
+       token: ${{ secrets.BROADBOT_TOKEN }}
+       repository: broadinstitute/terra-helmfile
+       event-type: update-service
+       client-payload: '{"service": "calhoun", "version": "${{ steps.short-sha.outputs.sha }}", "dev_only": false}'
     - name: Notify Slack
       # only notify for develop branch build
       if: github.event_name == 'push'

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -8,6 +8,7 @@ nbconvert==6.0.7
 nbformat==5.1.3
 requests==2.25.1
 rpy2==3.4.4
+beautifulsoup4==4.10.0
 
 # Transitive dependencies appear after this comment block in requirements.txt.
 # To update/freeze all transitive dependencies of requirements-min.txt:

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,3 +50,5 @@ tzlocal==2.1
 urllib3==1.26.5
 webencodings==0.5.1
 Werkzeug==2.0.1
+zipp==3.1.0
+beautifulsoup4==4.10.0

--- a/utils.py
+++ b/utils.py
@@ -10,6 +10,7 @@ from werkzeug.exceptions import *
 from rpy2.robjects.packages import importr
 import json
 import os
+import logging
 from bs4 import BeautifulSoup
 
 def perform_notebook_conversion(notebook_json):
@@ -133,7 +134,7 @@ def remove_inline_scripts(html_doc):
     # Remove all script tags that dont have a src containing https://cdnjs.cloudflare.com, which is trusted via the terra-ui CSP
     # See this PR for implementation in UI https://github.com/DataBiosphere/terra-ui/pull/2438/files#diff-d506904027666817584075d2f1141152f8d72d02f355f39f3585453278ecdedbR24
     if len(allUntrustedJavascriptTags) > 0:
-        print(f"Detected preview has Javascript from an untrusted source. Removing {len(allUntrustedJavascriptTags)} count(s) as required by csp")
+        logging.info(f"Detected preview has Javascript from an untrusted source. Removing {len(allUntrustedJavascriptTags)} count(s) as required by csp")
         for untrustedScriptTag in allUntrustedJavascriptTags:
             untrustedScriptTag.decompose()
              

--- a/utils.py
+++ b/utils.py
@@ -123,7 +123,9 @@ def remove_inline_scripts(html_doc):
     # all previews will have this first script, as it is part of the nbconvert lib we use
     # on the other hand, any other scripts to remove are a result of python libs in a specific notebook relying on javascript to render output 
     mathJaxUnsafeScript = soup.select_one('script[type="text/x-mathjax-config"]')
-    mathJaxUnsafeScript.decompose()
+    
+    if mathJaxUnsafeScript is not None:
+        mathJaxUnsafeScript.decompose()
     
     allJavascriptTags = soup.findAll('script')
     allUntrustedJavascriptTags = list(filter(lambda scriptTag: not ('src' in scriptTag.attrs and 'https://cdnjs.cloudflare.com' in scriptTag['src']), allJavascriptTags))


### PR DESCRIPTION
This commit is based off HEAD~1, as the HEAD of this repo is for K8s deployment of kubernetes, and it is not in a good state as it was never finalized/deployed. I talked with @rtitle about this approach.

I will be rolling back dev to the commit this PR is based off of.

This PR scans the HTML output of nbconvert for <script> tags that violate the CSP and removes them. I verified that the preview still works after this (more information below).

There are two types of script tags removed by this PR:

- The mathjax config object, which is used to configure mathJax. This is a bit of a rabbit hole, but tl;dr since nbconvert is essentially the `client` of mathjax, it does not seem to be needed (tested with large notebooks by comparing previews to live terra-ui). If we find a use case for which it is needed, we can inject this config into the terra ui as per [this](http://docs.mathjax.org/en/v2.7-latest/configuration.html#using-plain-javascript). Hoowever, removing this config actually seems to fix some rendering issues in practice (local version is on left, version on right is app.terra.bio. Those are not actually links in blue.):

![image](https://user-images.githubusercontent.com/6465084/142035387-bd796717-6c83-4153-ad7e-09e541a4f971.png)

-  Script tags that are included in output cells. Various python packages use javascript to render output. We cannot support this and have a restrictive CSP at the same time. I think it is reasonable that we do not execute arbitrary javascript in a read-only preview, and process this out. Below is an example of what this looks like in practice (local on left, app.terra.bio on right)

![image](https://user-images.githubusercontent.com/6465084/142035433-05285539-de0b-4f23-b71f-b552b51077be.png)

Script tags that do not violate the CSP are not removed. See inlne comments.

I tested this extensively by first replicating the CSP error using a local calhoun and terra-ui:

![image](https://user-images.githubusercontent.com/6465084/142035502-1b7c7278-2522-45b1-812c-9f7ca56af14c.png)

And then manually editing the HTML to make the CSP happy before implementing the programatic fixes

![image](https://user-images.githubusercontent.com/6465084/142035563-3cbc0495-51a8-4e76-80b2-6892457991a2.png)


