### PR TITLE
[IA-3403] Fix 500 internal server error when rendering R Notebook file

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -38,15 +38,16 @@ def perform_rmd_conversion(stream):
         # Call R rmarkdown package from python.
         # See https://cran.r-project.org/web/packages/rmarkdown/index.html
         rmd = importr("rmarkdown")
-        rmd.render(in_file.name)
-
-        out_path = os.path.splitext(in_file.name)[0] + ".html"
+        renderedrmd = rmd.render(in_file.name)
+        out_path = renderedrmd[0]
+        
         try:
             out_file = open(out_path)
-            return out_file.read()
+            read_outfile = out_file.read()
         finally:
             out_file.close()
             os.remove(out_path)
+        return read_outfile
 
 
 # Authorization decorator

--- a/utils.py
+++ b/utils.py
@@ -38,8 +38,8 @@ def perform_rmd_conversion(stream):
         # Call R rmarkdown package from python.
         # See https://cran.r-project.org/web/packages/rmarkdown/index.html
         rmd = importr("rmarkdown")
-        renderedrmd = rmd.render(in_file.name)
-        out_path = renderedrmd[0]
+        rendered_html = rmd.render(in_file.name)
+        out_path = rendered_html[0]
         
         try:
             out_file = open(out_path)


### PR DESCRIPTION
## Description
Users were having errors rendering R Notebook files

## Issue
There were file not found scenarios that were not being handled properly - the rendering was working, but we could not find the file due to the ".nb" file extension being appended before the ".html"


## Implementation
Instead of constructing the output file path, take the file path from the rmd.render() call and use that to open and send the file.


Jira Ticket 
https://broadworkbench.atlassian.net/browse/IA-3403