### PR TITLE
[IA-3606] Fix failing GHA automation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       id: short-sha
       run: echo "::set-output name=sha::$(git rev-parse --short=12 HEAD)"
     - name: Auth to GCR
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0.3.0
       with:
         version: '270.0.0'
         service_account_email: ${{ secrets.GCR_PUBLISH_EMAIL }}

--- a/README.md
+++ b/README.md
@@ -73,10 +73,9 @@ if __name__ == '__main__':
     app.run(port=8080, host='0.0.0.0', ssl_context=('/etc/ssl/certs/server.crt', '/etc/ssl/certs/server.key'))
 ```
 
-Edit config.py to use development authentication, and enable flask debug mode.
+Edit config.py to use development authentication.
 ``` py
 SAM_ROOT = 'https://sam.dsde-dev.broadinstitute.org'
-FLASK_DEBUG=1
 ```
 
 Run a local server

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A swagger-ui page is available at /swagger-ui/ on any running instance. For exis
 ### Framework
 This project uses the [Flask](https://flask.palletsprojects.com/en/1.1.x/) Python web framework.
 
-### Developing
+## Developing
 Install dependencies
 
 ```sh
@@ -36,15 +36,44 @@ pip install -r requirements-min.txt
 export FLASK_DEBUG=1
 ```
 
+### R dependencies
+
+Install [Pandoc](https://pandoc.org/installing.html)
+```sh
+brew install pandoc
+```
+
+```sh
+R
+> install.packages(c("rmarkdown", "stringi", "tidyverse", "Seurat", "ggforce"))
+```
+
 
 Write a config file
 ```sh
 cp config.dev.py config.py
 ```
 
+Ensure hosts file has the following record:
+```
+127.0.0.1       local.dsde-dev.broadinstitute.org
+```
+
+Update main.py to use Broad's wildcard SSL certificates.
+These certificates are the same ones used for any of our web applications.
+For ease of use, copy to `/etc/ssl/certs`.
+```py
+if __name__ == '__main__':
+    app.run(port=8080, host='0.0.0.0', ssl_context=('/etc/ssl/certs/server.crt', '/etc/ssl/certs/server.key'))
+```
+
 Run a local server
 ```sh
 FLASK_DEBUG=1 python3 main.py
+```
+Run local server with development authentication
+```sh
+FLASK_DEBUG=1 SAM_ROOT='https://sam.dsde-dev.broadinstitute.org' python3 main.py
 ```
 
 Or, run a local containerized server which is useful for testing R functionality

--- a/README.md
+++ b/README.md
@@ -61,19 +61,27 @@ Ensure hosts file has the following record:
 
 Update main.py to use Broad's wildcard SSL certificates.
 These certificates are the same ones used for any of our web applications.
-For ease of use, copy to `/etc/ssl/certs`.
+To get these certificates, run the `configure.rb` script by following the instructions under the title [Running Leo Locally](https://broadworkbench.atlassian.net/wiki/spaces/IA/pages/104399223/Callisto+Developer+Handbook#CallistoDeveloperHandbook-RunningLeoLocally)
+
+Once complete, copy `leonardo/config/server.*` to `/etc/ssl/certs`.
+
+Configure flask to look for the SSL Certificates
+
 ```py
+# main.py
 if __name__ == '__main__':
     app.run(port=8080, host='0.0.0.0', ssl_context=('/etc/ssl/certs/server.crt', '/etc/ssl/certs/server.key'))
 ```
 
+Edit config.py to use development authentication, and enable debugging.
+``` py
+SAM_ROOT = 'https://sam.dsde-dev.broadinstitute.org'
+FLASK_DEBUG=1
+```
+
 Run a local server
 ```sh
-FLASK_DEBUG=1 python3 main.py
-```
-Run local server with development authentication
-```sh
-FLASK_DEBUG=1 SAM_ROOT='https://sam.dsde-dev.broadinstitute.org' python3 main.py
+python3 main.py
 ```
 
 Or, run a local containerized server which is useful for testing R functionality

--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ docker kill t1
 docker run -e FLASK_DEBUG=1 --rm -itd --name t1 -p 8080:8080 calhoun-test:0
 ```
 
-Load pages from localhost:
-* http://localhost:8080/status
-* http://localhost:8080/api/docs/
+Access the application locally:
+* https://local.dsde-dev.broadinstitute.org:8080/status
+* https://local.dsde-dev.broadinstitute.org:8080/api/docs/
 
 Run unit tests locally
 ```sh

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ if __name__ == '__main__':
     app.run(port=8080, host='0.0.0.0', ssl_context=('/etc/ssl/certs/server.crt', '/etc/ssl/certs/server.key'))
 ```
 
-Edit config.py to use development authentication, and enable debugging.
+Edit config.py to use development authentication, and enable flask debug mode.
 ``` py
 SAM_ROOT = 'https://sam.dsde-dev.broadinstitute.org'
 FLASK_DEBUG=1

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -4,12 +4,11 @@ Flask==2.1.3
 Flask-Cors==3.0.10
 flask-talisman==0.7.0
 flask-swagger-ui==3.36.0
-nbconvert==6.0.7
+nbconvert>=6.0.7
 nbformat==5.1.3
 requests==2.25.1
 rpy2==3.4.4
 beautifulsoup4==4.10.0
-Jinja2==3.0.0
 
 # Transitive dependencies appear after this comment block in requirements.txt.
 # To update/freeze all transitive dependencies of requirements-min.txt:

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,6 +1,6 @@
 # Explicit dependencies
 
-Flask==1.1.2
+Flask==2.1.3
 Flask-Cors==3.0.10
 flask-talisman==0.7.0
 flask-swagger-ui==3.36.0
@@ -9,6 +9,7 @@ nbformat==5.1.3
 requests==2.25.1
 rpy2==3.4.4
 beautifulsoup4==4.10.0
+Jinja2==3.0.0
 
 # Transitive dependencies appear after this comment block in requirements.txt.
 # To update/freeze all transitive dependencies of requirements-min.txt:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask==1.1.2
 Flask-Cors==3.0.10
 flask-talisman==0.7.0
 flask-swagger-ui==3.36.0
-nbconvert==6.0.7
+nbconvert>=6.0.7
 nbformat==5.1.3
 requests==2.25.1
 rpy2==3.4.4


### PR DESCRIPTION
## Description

Docker build command is failing.
The issue is `ImportError: cannot import name 'contextfilter' from 'jinja2'`

To fix this, we need to lock the Jinja2 version to 3.0. OR unpin nbconvert.

Solution sourced from here:
https://github.com/d2l-ai/d2l-book/issues/46