### PR TITLE
[IA-3667] updating R installed packages to fix preview issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-RUN R -e 'install.packages("rmarkdown")'
+RUN R -e 'install.packages(c("rmarkdown", "stringi", "tidyverse", "Seurat", "ggforce"))'
 
 COPY . /work
 WORKDIR /work


### PR DESCRIPTION
In order to generate a notebook preview, Calhoun needs to render the notebook. This means that Calhoun will need all of the required packages that a cloud environment would need in order to "knit" the file

We can see this through the Calhoun error logs: 
<img width="1277" alt="Screen Shot 2022-09-08 at 12 51 04 PM" src="https://user-images.githubusercontent.com/62293969/189425024-059ff5c3-d537-4186-99b9-6bec930c1718.png">

In the short term, we will need to add the packages to the Calhoun Docker file in order to properly generate the preview in particular for the user's issue.

You can test this locally by manually installing the packages in your local R environment with a local Calhoun and then try to preview the relevant notebook