### PR TITLE
[IA-3667] add packages for seurat install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   r-base \
   r-base-dev \
   pandoc \
+  && apt update \
+  && apt install -yq --no-install-recommends \
+  libcurl4-openssl-dev \
+  libssl-dev \
+  libgeos-dev \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Noticed that our last fix did not entirely fix the Seurat portion of the package installs. We needed to add some additional packages within Calhoun to get this to work.

Still no able to figure out the bash issue. Potentially could be related to not have the right version of Java installed here