### PR TITLE
[IA-3991] Fix tag-build-push v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,9 @@ jobs:
       id: 'auth'
       uses: 'google-github-actions/auth@v1'
       with:
-        credentials_json: '${{ secrets.GCR_PUBLISH_KEY }}'
+        credentials_json: '${{ secrets.GCR_PUBLISH_KEY_B64 }}'
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@v0
     - name: Auth Docker for GCR
       run: gcloud auth configure-docker --quiet
     - name: Construct tags

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,6 @@ jobs:
       uses: 'google-github-actions/auth@v1'
       with:
         credentials_json: '${{ secrets.GCR_PUBLISH_KEY }}'
-    - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v0
     - name: Auth Docker for GCR
       run: gcloud auth configure-docker --quiet
     - name: Construct tags


### PR DESCRIPTION
This is the final iteration to fix the build.yml.
Part of merging the previous PR was to ensure the Gitignore file was updated properly.