### PR TITLE
[IA-4170] Fix security vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ brew install pandoc
 ```
 
 ```sh
+brew install R
 R
 > install.packages(c("rmarkdown", "stringi", "tidyverse", "Seurat", "ggforce"))
 ```

--- a/main.py
+++ b/main.py
@@ -61,11 +61,12 @@ def convert():
 
 @app.route('/api/convert/rmd', methods={'POST'})
 @cross_origin()
-@authorized(app.config['SAM_ROOT'])
+# @authorized(app.config['SAM_ROOT'])
 def convert_rmd():
     stream = request.stream
     return perform_rmd_conversion(stream)
 
 
 if __name__ == '__main__':
-    app.run(port=8080, host='0.0.0.0')
+    # app.run(port=8080, host='0.0.0.0')
+    app.run(port=8080, host='0.0.0.0', ssl_context=('/etc/ssl/certs/server.crt', '/etc/ssl/certs/server.key'))

--- a/main.py
+++ b/main.py
@@ -61,12 +61,13 @@ def convert():
 
 @app.route('/api/convert/rmd', methods={'POST'})
 @cross_origin()
-# @authorized(app.config['SAM_ROOT'])
+@authorized(app.config['SAM_ROOT'])
 def convert_rmd():
     stream = request.stream
     return perform_rmd_conversion(stream)
 
 
 if __name__ == '__main__':
-    # app.run(port=8080, host='0.0.0.0')
-    app.run(port=8080, host='0.0.0.0', ssl_context=('/etc/ssl/certs/server.crt', '/etc/ssl/certs/server.key'))
+    app.run(port=8080, host='0.0.0.0')
+    # Uncomment below line for local running
+    # app.run(port=8080, host='0.0.0.0', ssl_context=('/etc/ssl/certs/server.crt', '/etc/ssl/certs/server.key'))

--- a/utils.py
+++ b/utils.py
@@ -29,7 +29,7 @@ def perform_notebook_conversion(notebook_json):
 def perform_rmd_conversion(stream):
     binary_data = stream.read()
     data = binary_data.decode('ascii')
-    sanitized_data = sanitize_rmd(data)
+    sanitized_data = __sanitize_rmd(data)
     
     # The rmarkdown converter unfortunately only works with files.
     # So we create temp files for the source markdown and destination html data.
@@ -57,10 +57,10 @@ def perform_rmd_conversion(stream):
 # Actually executes any code in a labeled codeblock. By processing out any of these labels, we ensure we display a preview without a possible arbitrary code execution vulnerability
 # See this document, issue number one, for more details on the vulnerability: https://docs.google.com/document/d/1aNCOKitTJH-GEkBSR4i-x91O0OQCZ8ZYa3feXtkja94/edit#heading=h.rvpr6zoz0jem 
 # Takes a string and returns binary
-def sanitize_rmd(data):
-    print('printing data to sanitize pre-split', data)
+def __sanitize_rmd(data: str) -> bytes:
+    logging.info(f'printing data to sanitize pre-split: {data}')
     lines = data.split('\n')
-    print('printing lines of file', lines)
+    logging.info(f'printing lines of file: {lines}')
     sanitized_file = []
     for line in lines:
         if line.startswith('```'):
@@ -70,7 +70,7 @@ def sanitize_rmd(data):
         sanitized_file.append(sanitized_line)    
         
     file = '\n'.join(sanitized_file)
-    print('putting data put back together', file)
+    logging.info(f'putting data put back together {file}')
     
     return file.encode('ascii')
 

--- a/utils.py
+++ b/utils.py
@@ -52,12 +52,13 @@ def perform_rmd_conversion(stream):
             os.remove(out_path)
         return read_outfile
     
-# We need to sanitize any code blocks (ex ```{bash}) from the rmd before rendering it
-# This is because kitr (https://rmarkdown.rstudio.com/authoring_quick_tour.html#Rendering_Output.), which powers our rendering
-# Actually executes any code in a labeled codeblock. By processing out any of these labels, we ensure we display a preview without a possible arbitrary code execution vulnerability
-# See this document, issue number one, for more details on the vulnerability: https://docs.google.com/document/d/1aNCOKitTJH-GEkBSR4i-x91O0OQCZ8ZYa3feXtkja94/edit#heading=h.rvpr6zoz0jem 
-# Takes a string and returns binary
 def __sanitize_rmd(data: str) -> bytes:
+    """
+    We need to sanitize any code blocks (ex ```{bash}) from the rmd before rendering it
+    This is because kitr (https://rmarkdown.rstudio.com/authoring_quick_tour.html#Rendering_Output.), which powers our rendering
+    Actually executes any code in a labeled codeblock. By processing out any of these labels, we ensure we display a preview without a possible arbitrary code execution vulnerability
+    See this document, issue number one, for more details on the vulnerability: https://docs.google.com/document/d/1aNCOKitTJH-GEkBSR4i-x91O0OQCZ8ZYa3feXtkja94/edit#heading=h.rvpr6zoz0jem 
+    """
     logging.info(f'printing data to sanitize pre-split: {data}')
     lines = data.split('\n')
     logging.info(f'printing lines of file: {lines}')

--- a/utils.py
+++ b/utils.py
@@ -28,19 +28,15 @@ def perform_notebook_conversion(notebook_json):
 
 def perform_rmd_conversion(stream):
     binary_data = stream.read()
-    # data = binary_data.decode('ascii')
-    sanitized_data = binary_data#sanitize_rmd(data)
-    
-    # incoming_data = FileStorage(stream)
+    data = binary_data.decode('ascii')
+    sanitized_data = sanitize_rmd(data)
     
     # The rmarkdown converter unfortunately only works with files.
     # So we create temp files for the source markdown and destination html data.
     # The temp files are deleted as soon as the below with block ends.
     with NamedTemporaryFile(suffix=".Rmd") as in_file:
         in_file.write(sanitized_data) 
-        
         in_file.seek(0)
-        print('temp file contents', in_file.read())
 
         # Call R rmarkdown package from python.
         # See https://cran.r-project.org/web/packages/rmarkdown/index.html


### PR DESCRIPTION
This fixes a security vulnerability in which you code specify a language in a code block in a rmd (aka .md) file, and the calhoun server would execute that code. Details about how exactly the fix works is in the code file in a comment. Essentially, I tap into the syntax of the underlying markdown render and pre-process any lines that would result in code execution out. For Jupyter, the output is stored in the `.ipynb` format, and 'pre-rendered' and ran on the user's VM. .md files don't have any 'outputs' section, so here we decide to forgo any calhoun-side execution for security reasons. This approach was ran past the AnVIL folks.

I tested this by pointing a local terra-ui at my local calhoun server.

Before sanitization, arbitrary bash executed on server (`hostname` command):
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/6465084/233146394-2530f6a4-4d02-4342-a5e2-35c23223469c.png">

After sanitization:

<img width="1676" alt="image" src="https://user-images.githubusercontent.com/6465084/233145912-d682361c-c5dc-4509-83dd-27c767c1e89e.png">
